### PR TITLE
SDCard related code

### DIFF
--- a/romfs/sdcard.lua
+++ b/romfs/sdcard.lua
@@ -24,7 +24,7 @@ end
 
 function sdmodule.is_inserted()
     -- Make sure the pin is in correct mode
-    pio.pin.setdir(pio.INPUT, sdmodule.enable_pin)
+    pio.pin.setdir(pio.INPUT, sdmodule.inserted_pin)
     pio.pin.setpull(pio.PULLUP, sdmodule.inserted_pin)
     return (pio.pin.getval(sdmodule.inserted_pin) == 0)
 end
@@ -53,6 +53,7 @@ function sdmodule.enable()
     end
     pio.pin.setdir(pio.OUTPUT, sdmodule.enable_pin)
     pio.pin.sethigh(sdmodule.enable_pin)
+    return true
 end
 
 

--- a/romfs/sdcard.lua
+++ b/romfs/sdcard.lua
@@ -5,6 +5,8 @@ sd = require "sdcard"
 sd.enable() return boolean if the operation was successfull or not (fails if no card inserted)
 sd.disable() will always succeed
 sd.is_inserted() returns boolean
+sd.is_enabled() return the enable status, will also return failure if card not inserted
+
 
 --]]--
 
@@ -18,14 +20,23 @@ then
 end
 
 
-local function is_inserted()
+function sdmodule.is_inserted()
     -- Make sure the pin is in correct mode
     pio.pin.setdir(pio.INPUT, enable_pin)
     pio.pin.setpull(pio.PULLUP, inserted_pin)
     return (pio.pin.getval(inserted_pin) == 0)
 end
 
-local function disable()
+function sdmodule.is_enabled()
+    -- Make sure the pin is in correct mode
+    if (not sdmodule.is_inserted())
+    then
+        return false
+    end
+    return (pio.pin.getval(sdmodule.enable_pin) == 1)
+end
+
+function sdmodule.disable()
     -- let the pull-down resistor on the board shut down the regulator
     pio.pin.setdir(pio.INPUT, enable_pin)
     pio.pin.setpull(pio.NOPULL, enable_pin)
@@ -33,8 +44,8 @@ local function disable()
     pio.pin.setpull(pio.NOPULL, inserted_pin)
 end
 
-local function enable()
-    if (not is_inserted())
+function sdmodule.enable()
+    if (not sdmodule.is_inserted())
     then
         return false
     end
@@ -42,9 +53,6 @@ local function enable()
     pio.pin.sethigh(enable_pin)
 end
 
-sdmodule.enable = enable
-sdmodule.is_inserted = is_inserted
-sdmodule.disable = disable
 
 return sdmodule
 

--- a/romfs/sdcard.lua
+++ b/romfs/sdcard.lua
@@ -35,7 +35,7 @@ function sdmodule.is_enabled()
     then
         return false
     end
-    return (pio.pin.getval(sdmodule.sdmodule.enable_pin) == 1)
+    return (pio.pin.getval(sdmodule.enable_pin) == 1)
 end
 
 function sdmodule.disable()

--- a/romfs/sdcard.lua
+++ b/romfs/sdcard.lua
@@ -5,9 +5,11 @@ sd = require "sdcard"
 sd.enable() return boolean if the operation was successfull or not (fails if no card inserted)
 sd.disable() will always succeed
 sd.is_inserted() returns boolean
-sd.is_enabled() return the enable status, will also return failure if card not inserted
-
-
+sd.is_enabled() return the enable status, will also return failure if card not inserted. 
+                NOTE! This does not actually tell you if the card is ready/working/whatnot, it seems eLua
+                does not like having the card come and go, you should never try to access the card when
+                it's not enabled, this will likely mess up eLua/FatFS and prevent you accessing the card
+                until next reboot...
 --]]--
 
 local sdmodule = {}

--- a/romfs/sdcard.lua
+++ b/romfs/sdcard.lua
@@ -1,0 +1,50 @@
+--[[--
+Use with:
+sd = require "sdcard"
+
+sd.enable() return boolean if the operation was successfull or not (fails if no card inserted)
+sd.disable() will always succeed
+sd.is_inserted() returns boolean
+
+--]]--
+
+local sdmodule = {}
+
+-- Board specifig config
+if pd.board() == "RUUVIC1"
+then
+   local inserted_pin = pio.PC_10
+   local enable_pin   = pio.PC_8
+end
+
+
+local function is_inserted()
+    -- Make sure the pin is in correct mode
+    pio.pin.setdir(pio.INPUT, enable_pin)
+    pio.pin.setpull(pio.PULLUP, inserted_pin)
+    return (pio.pin.getval(inserted_pin) == 0)
+end
+
+local function disable()
+    -- let the pull-down resistor on the board shut down the regulator
+    pio.pin.setdir(pio.INPUT, enable_pin)
+    pio.pin.setpull(pio.NOPULL, enable_pin)
+    -- And disable pullup on the sense pin as well, just in case it would matter at all
+    pio.pin.setpull(pio.NOPULL, inserted_pin)
+end
+
+local function enable()
+    if (not is_inserted())
+    then
+        return false
+    end
+    pio.pin.setdir(pio.OUTPUT, enable_pin)
+    pio.pin.sethigh(enable_pin)
+end
+
+sdmodule.enable = enable
+sdmodule.is_inserted = is_inserted
+sdmodule.disable = disable
+
+return sdmodule
+

--- a/romfs/sdcard.lua
+++ b/romfs/sdcard.lua
@@ -17,16 +17,16 @@ local sdmodule = {}
 -- Board specifig config
 if pd.board() == "RUUVIC1"
 then
-   local inserted_pin = pio.PC_10
-   local enable_pin   = pio.PC_8
+    sdmodule.inserted_pin = pio.PC_10
+    sdmodule.enable_pin   = pio.PC_8
 end
 
 
 function sdmodule.is_inserted()
     -- Make sure the pin is in correct mode
-    pio.pin.setdir(pio.INPUT, enable_pin)
-    pio.pin.setpull(pio.PULLUP, inserted_pin)
-    return (pio.pin.getval(inserted_pin) == 0)
+    pio.pin.setdir(pio.INPUT, sdmodule.enable_pin)
+    pio.pin.setpull(pio.PULLUP, sdmodule.inserted_pin)
+    return (pio.pin.getval(sdmodule.inserted_pin) == 0)
 end
 
 function sdmodule.is_enabled()
@@ -35,15 +35,15 @@ function sdmodule.is_enabled()
     then
         return false
     end
-    return (pio.pin.getval(sdmodule.enable_pin) == 1)
+    return (pio.pin.getval(sdmodule.sdmodule.enable_pin) == 1)
 end
 
 function sdmodule.disable()
     -- let the pull-down resistor on the board shut down the regulator
-    pio.pin.setdir(pio.INPUT, enable_pin)
-    pio.pin.setpull(pio.NOPULL, enable_pin)
+    pio.pin.setdir(pio.INPUT, sdmodule.enable_pin)
+    pio.pin.setpull(pio.NOPULL, sdmodule.enable_pin)
     -- And disable pullup on the sense pin as well, just in case it would matter at all
-    pio.pin.setpull(pio.NOPULL, inserted_pin)
+    pio.pin.setpull(pio.NOPULL, sdmodule.inserted_pin)
 end
 
 function sdmodule.enable()
@@ -51,8 +51,8 @@ function sdmodule.enable()
     then
         return false
     end
-    pio.pin.setdir(pio.OUTPUT, enable_pin)
-    pio.pin.sethigh(enable_pin)
+    pio.pin.setdir(pio.OUTPUT, sdmodule.enable_pin)
+    pio.pin.sethigh(sdmodule.enable_pin)
 end
 
 

--- a/src/main.c
+++ b/src/main.c
@@ -92,10 +92,11 @@ int main( void )
 	// Register the ROM filesystem
 	romfs_init();
 
-    // TODO: Check the actual board revision first! 
+#if defined( ELUA_BOARD_RUUVIC1 )
     // Enable the reg for mmc card (ruuviC1). The card *must* have power when we try to initialize it or it will not work later either...
     platform_pio_op(2, ( ( u32 ) 1 << 8 ), PLATFORM_IO_PIN_DIR_OUTPUT );
     platform_pio_op(2, ( ( u32 ) 1 << 8 ), PLATFORM_IO_PIN_SET );
+#endif
 	// Register the MMC filesystem
 	mmcfs_init();
 

--- a/src/main.c
+++ b/src/main.c
@@ -92,6 +92,10 @@ int main( void )
 	// Register the ROM filesystem
 	romfs_init();
 
+    // TODO: Check the actual board revision first! 
+    // Enable the reg for mmc card (ruuviC1). The card *must* have power when we try to initialize it or it will not work later either...
+    platform_pio_op(2, ( ( u32 ) 1 << 8 ), PLATFORM_IO_PIN_DIR_OUTPUT );
+    platform_pio_op(2, ( ( u32 ) 1 << 8 ), PLATFORM_IO_PIN_SET );
 	// Register the MMC filesystem
 	mmcfs_init();
 

--- a/src/main.c
+++ b/src/main.c
@@ -92,10 +92,14 @@ int main( void )
 	// Register the ROM filesystem
 	romfs_init();
 
+#if defined(BUILD_MMCFS)
 #if defined( ELUA_BOARD_RUUVIC1 )
     // Enable the reg for mmc card (ruuviC1). The card *must* have power when we try to initialize it or it will not work later either...
     platform_pio_op(2, ( ( u32 ) 1 << 8 ), PLATFORM_IO_PIN_DIR_OUTPUT );
     platform_pio_op(2, ( ( u32 ) 1 << 8 ), PLATFORM_IO_PIN_SET );
+#else
+#error "Enable SDCard power in main.c or add a dummy define for your board if the card is always powered"
+#endif
 #endif
 	// Register the MMC filesystem
 	mmcfs_init();

--- a/src/main.c
+++ b/src/main.c
@@ -100,7 +100,8 @@ int main( void )
 #else
 #error "Enable SDCard power in main.c or add a dummy define for your board if the card is always powered"
 #endif
-#endif
+#endif // defined(BUILD_MMCFS)
+
 	// Register the MMC filesystem
 	mmcfs_init();
 

--- a/src/platform/stm32f4/platform_conf.h
+++ b/src/platform/stm32f4/platform_conf.h
@@ -172,7 +172,6 @@ extern int luaopen_ruuvi( lua_State *L );
 // For STM32F407VGT6 - PA5 = CLK, PA6 = MISO, PA7 = MOSI, PA4 = CS
 #define MMCFS_TICK_HZ                10
 #define MMCFS_TICK_MS                ( 1000 / MMCFS_TICK_HZ )
-// TODO: make these dependent on the defined board
 #if defined( ELUA_BOARD_RUUVIC1 )
 #define MMCFS_CS_PORT                1 // PB, see platform.c, keys start from 0
 #define MMCFS_CS_PIN                 15

--- a/src/platform/stm32f4/platform_conf.h
+++ b/src/platform/stm32f4/platform_conf.h
@@ -170,9 +170,16 @@ extern int luaopen_ruuvi( lua_State *L );
 // For STM32F407VGT6 - PA5 = CLK, PA6 = MISO, PA7 = MOSI, PA4 = CS
 #define MMCFS_TICK_HZ                10
 #define MMCFS_TICK_MS                ( 1000 / MMCFS_TICK_HZ )
-#define MMCFS_CS_PORT                1
-#define MMCFS_CS_PIN                 11
-#define MMCFS_SPI_NUM                1
+// TODO: make these dependent on the defined board
+#define MMCFS_CS_PORT                1 // PB, see platform.c, keys start from 0
+#define MMCFS_CS_PIN                 15
+#define MMCFS_SPI_NUM                0 // SPI1, see platform.c, keys start from zero
+// Actually probably just using the same kind of defines as in gsm.c would work better, anyway these are just reminders for now
+#define RUUVI_SDINSERTED_PORT        2  // PC
+#define RUUVI_SDINSERTED_PIN         10 
+#define RUUVI_SDLDO_PORT             2  // PC8
+#define RUUVI_SDLDO_PIN              8
+
 
 // CPU frequency (needed by the CPU module, 0 if not used)
 u32 platform_s_cpu_get_frequency();

--- a/src/platform/stm32f4/platform_conf.h
+++ b/src/platform/stm32f4/platform_conf.h
@@ -166,15 +166,21 @@ extern int luaopen_ruuvi( lua_State *L );
 #define RPC_UART_ID           CON_UART_ID
 #define RPC_UART_SPEED        CON_UART_SPEED
 
+
+#if defined(BUILD_MMCFS)
 // MMCFS Support (FatFs on SD/MMC)
 // For STM32F407VGT6 - PA5 = CLK, PA6 = MISO, PA7 = MOSI, PA4 = CS
 #define MMCFS_TICK_HZ                10
 #define MMCFS_TICK_MS                ( 1000 / MMCFS_TICK_HZ )
 // TODO: make these dependent on the defined board
+#if defined( ELUA_BOARD_RUUVIC1 )
 #define MMCFS_CS_PORT                1 // PB, see platform.c, keys start from 0
 #define MMCFS_CS_PIN                 15
 #define MMCFS_SPI_NUM                0 // SPI1, see platform.c, keys start from zero
-
+#else
+#error "Define SDCard MMCFS_XXX constants in platform_conf.h"
+#endif
+#endif // defined(BUILD_MMCFS)
 
 // CPU frequency (needed by the CPU module, 0 if not used)
 u32 platform_s_cpu_get_frequency();

--- a/src/platform/stm32f4/platform_conf.h
+++ b/src/platform/stm32f4/platform_conf.h
@@ -174,11 +174,6 @@ extern int luaopen_ruuvi( lua_State *L );
 #define MMCFS_CS_PORT                1 // PB, see platform.c, keys start from 0
 #define MMCFS_CS_PIN                 15
 #define MMCFS_SPI_NUM                0 // SPI1, see platform.c, keys start from zero
-// Actually probably just using the same kind of defines as in gsm.c would work better, anyway these are just reminders for now
-#define RUUVI_SDINSERTED_PORT        2  // PC
-#define RUUVI_SDINSERTED_PIN         10 
-#define RUUVI_SDLDO_PORT             2  // PC8
-#define RUUVI_SDLDO_PIN              8
 
 
 // CPU frequency (needed by the CPU module, 0 if not used)


### PR DESCRIPTION
The card regulator must be enabled when the board powers up, otherwise it will never work. Define correct pins for revC1, some Lua level helpers for checking card status and enabling/disabling regulator for it.
