### PR TITLE
Revc1i2c

### DIFF
--- a/inc/platform.h
+++ b/inc/platform.h
@@ -291,9 +291,9 @@ rt_error platform_i2c_send_address( unsigned id, u16 address, int direction );
 rt_error platform_i2c_send_byte( unsigned id, u8 data );
 rt_error platform_i2c_recv_byte( unsigned id, int ack, u8 *buff );
 rt_error platform_i2c_read8(unsigned id, u8 device, u8 offset, u8 *buff, int len, int *recv_count);
-int platform_i2c_write8(unsigned id, u8 device, u8 offset, u8 *buff, int len);
+rt_error platform_i2c_write8(unsigned id, u8 device, u8 offset, u8 *buff, int len, int *send_count);
 rt_error platform_i2c_read16(unsigned id, u8 device, u16 offset, u8 *buff, int len, int *recv_count);
-int platform_i2c_write16(unsigned id, u8 device, u16 offset, u8 *buff, int len);
+rt_error platform_i2c_write16(unsigned id, u8 device, u16 offset, u8 *buff, int len, int *send_count);
 
 // *****************************************************************************
 // Ethernet specific functions

--- a/inc/platform.h
+++ b/inc/platform.h
@@ -288,11 +288,11 @@ u32 platform_i2c_setup( unsigned id, u32 speed );
 rt_error platform_i2c_send_start( unsigned id );
 rt_error platform_i2c_send_stop( unsigned id );
 rt_error platform_i2c_send_address( unsigned id, u16 address, int direction );
-int platform_i2c_send_byte( unsigned id, u8 data );
-int platform_i2c_recv_byte( unsigned id, int ack );
-int platform_i2c_read8(unsigned id, u8 device, u8 offset, u8 *buff, int len);
+rt_error platform_i2c_send_byte( unsigned id, u8 data );
+rt_error platform_i2c_recv_byte( unsigned id, int ack, u8 *buff );
+rt_error platform_i2c_read8(unsigned id, u8 device, u8 offset, u8 *buff, int len, int *recv_count);
 int platform_i2c_write8(unsigned id, u8 device, u8 offset, u8 *buff, int len);
-int platform_i2c_read16(unsigned id, u8 device, u16 offset, u8 *buff, int len);
+rt_error platform_i2c_read16(unsigned id, u8 device, u16 offset, u8 *buff, int len, int *recv_count);
 int platform_i2c_write16(unsigned id, u8 device, u16 offset, u8 *buff, int len);
 
 // *****************************************************************************

--- a/inc/platform.h
+++ b/inc/platform.h
@@ -6,6 +6,7 @@
 #include "devman.h"
 #include "type.h"
 #include "elua_int.h"
+#include "ruuvi_errors.h"
 
 // Error / status codes
 enum {
@@ -284,8 +285,8 @@ enum {
 
 int platform_i2c_exists( unsigned id );
 u32 platform_i2c_setup( unsigned id, u32 speed );
-void platform_i2c_send_start( unsigned id );
-void platform_i2c_send_stop( unsigned id );
+rt_error platform_i2c_send_start( unsigned id );
+rt_error platform_i2c_send_stop( unsigned id );
 int platform_i2c_send_address( unsigned id, u16 address, int direction );
 int platform_i2c_send_byte( unsigned id, u8 data );
 int platform_i2c_recv_byte( unsigned id, int ack );

--- a/inc/platform.h
+++ b/inc/platform.h
@@ -287,7 +287,7 @@ int platform_i2c_exists( unsigned id );
 u32 platform_i2c_setup( unsigned id, u32 speed );
 rt_error platform_i2c_send_start( unsigned id );
 rt_error platform_i2c_send_stop( unsigned id );
-int platform_i2c_send_address( unsigned id, u16 address, int direction );
+rt_error platform_i2c_send_address( unsigned id, u16 address, int direction );
 int platform_i2c_send_byte( unsigned id, u8 data );
 int platform_i2c_recv_byte( unsigned id, int ack );
 int platform_i2c_read8(unsigned id, u8 device, u8 offset, u8 *buff, int len);

--- a/inc/ruuvi_errors.h
+++ b/inc/ruuvi_errors.h
@@ -13,6 +13,7 @@ typedef enum rt_error
 
 #define RT_DEFAULT_TIMEOUT (150) // ms
 #define RT_TIMEOUT_INIT() unsigned int RT_TIMEOUT_STARTED = systick_get_raw();
+#define RT_TIMEOUT_REINIT() RT_TIMEOUT_STARTED = systick_get_raw();
 #define RT_TIMEOUT_CHECK(ms) if ((RT_TIMEOUT_STARTED - systick_get_raw()) > ms) { return RT_ERR_TIMEOUT; }
 
 #endif

--- a/inc/ruuvi_errors.h
+++ b/inc/ruuvi_errors.h
@@ -1,5 +1,6 @@
 #ifndef __RUUVI_ERRORS_H__
 #define __RUUVI_ERRORS_H__
+#include "delay.h"
 
 typedef enum rt_error
 {
@@ -10,6 +11,8 @@ typedef enum rt_error
     
 } rt_error;
 
-
+#define RT_DEFAULT_TIMEOUT (150) // ms
+#define RT_TIMEOUT_INIT() unsigned int RT_TIMEOUT_STARTED = systick_get_raw();
+#define RT_TIMEOUT_CHECK(ms) if ((RT_TIMEOUT_STARTED - systick_get_raw()) > ms) { return RT_ERR_TIMEOUT; }
 
 #endif

--- a/inc/ruuvi_errors.h
+++ b/inc/ruuvi_errors.h
@@ -4,6 +4,8 @@
 
 #ifndef D_EXIT
 #define D_EXIT()
+#endif
+#ifndef _DEBUG
 #define _DEBUG(fmt, args...)
 #endif
 

--- a/inc/ruuvi_errors.h
+++ b/inc/ruuvi_errors.h
@@ -2,11 +2,17 @@
 #define __RUUVI_ERRORS_H__
 #include "delay.h"
 
+#ifndef D_EXIT
+#define D_EXIT()
+#define _DEBUG(fmt, args...)
+#endif
+
 typedef enum rt_error
 {
     RT_ERR_OK = 0,
-    RT_ERR_TIMEOUT = -1, // obviously timeout
-    RT_ERR_ERROR = -2 // General error
+    RT_ERR_FAIL = -1, // Failure, not really an error, it might be normal and expected even, just an easier way to pass boolean status to the caller
+    RT_ERR_TIMEOUT = -2, // obviously timeout
+    RT_ERR_ERROR = -3 // General error
     // Add more error codes as we get there
     
 } rt_error;
@@ -14,6 +20,6 @@ typedef enum rt_error
 #define RT_DEFAULT_TIMEOUT (150) // ms
 #define RT_TIMEOUT_INIT() unsigned int RT_TIMEOUT_STARTED = systick_get_raw();
 #define RT_TIMEOUT_REINIT() RT_TIMEOUT_STARTED = systick_get_raw();
-#define RT_TIMEOUT_CHECK(ms) if ((systick_get_raw() - RT_TIMEOUT_STARTED) > ms) { return RT_ERR_TIMEOUT; }
+#define RT_TIMEOUT_CHECK(ms) if ((systick_get_raw() - RT_TIMEOUT_STARTED) > ms) { _DEBUG("%s\n", "timeout!"); D_EXIT(); return RT_ERR_TIMEOUT; }
 
 #endif

--- a/inc/ruuvi_errors.h
+++ b/inc/ruuvi_errors.h
@@ -1,0 +1,15 @@
+#ifndef __RUUVI_ERRORS_H__
+#define __RUUVI_ERRORS_H__
+
+typedef enum rt_error
+{
+    RT_ERR_OK = 0,
+    RT_ERR_TIMEOUT = -1, // obviously timeout
+    RT_ERR_ERROR = -2 // General error
+    // Add more error codes as we get there
+    
+} rt_error;
+
+
+
+#endif

--- a/inc/ruuvi_errors.h
+++ b/inc/ruuvi_errors.h
@@ -17,7 +17,7 @@ typedef enum rt_error
     
 } rt_error;
 
-#define RT_DEFAULT_TIMEOUT (150) // ms
+#define RT_DEFAULT_TIMEOUT (1500) // ms
 #define RT_TIMEOUT_INIT() unsigned int RT_TIMEOUT_STARTED = systick_get_raw();
 #define RT_TIMEOUT_REINIT() RT_TIMEOUT_STARTED = systick_get_raw();
 #define RT_TIMEOUT_CHECK(ms) if ((systick_get_raw() - RT_TIMEOUT_STARTED) > ms) { _DEBUG("%s\n", "timeout!"); D_EXIT(); return RT_ERR_TIMEOUT; }

--- a/inc/ruuvi_errors.h
+++ b/inc/ruuvi_errors.h
@@ -14,6 +14,6 @@ typedef enum rt_error
 #define RT_DEFAULT_TIMEOUT (150) // ms
 #define RT_TIMEOUT_INIT() unsigned int RT_TIMEOUT_STARTED = systick_get_raw();
 #define RT_TIMEOUT_REINIT() RT_TIMEOUT_STARTED = systick_get_raw();
-#define RT_TIMEOUT_CHECK(ms) if ((RT_TIMEOUT_STARTED - systick_get_raw()) > ms) { return RT_ERR_TIMEOUT; }
+#define RT_TIMEOUT_CHECK(ms) if ((systick_get_raw() - RT_TIMEOUT_STARTED) > ms) { return RT_ERR_TIMEOUT; }
 
 #endif

--- a/inc/ruuvi_errors.h
+++ b/inc/ruuvi_errors.h
@@ -19,7 +19,7 @@ typedef enum rt_error
     
 } rt_error;
 
-#define RT_DEFAULT_TIMEOUT (1500) // ms
+#define RT_DEFAULT_TIMEOUT (150) // ms
 #define RT_TIMEOUT_INIT() unsigned int RT_TIMEOUT_STARTED = systick_get_raw();
 #define RT_TIMEOUT_REINIT() RT_TIMEOUT_STARTED = systick_get_raw();
 #define RT_TIMEOUT_CHECK(ms) if ((systick_get_raw() - RT_TIMEOUT_STARTED) > ms) { _DEBUG("%s\n", "timeout!"); D_EXIT(); return RT_ERR_TIMEOUT; }

--- a/romfs/i2cdevice.lua
+++ b/romfs/i2cdevice.lua
@@ -9,6 +9,7 @@ Usage (without subclassing)
 i2cdev = require "i2cdevice"
 i2cdev.address_scan() -- Runs a scan for the 7-bit address space
 md = i2cdev.Device:new(0x1d)
+md:bus_init() -- setup the I2C bus
 md:present() -- returns true/false depending on whether the slave ACKed or not
 md:dump_registers(0x0, 0x31) -- this will do a bunch of sequential single byte reads
 md:write(reg, value)

--- a/romfs/i2cdevice.lua
+++ b/romfs/i2cdevice.lua
@@ -121,10 +121,10 @@ function Device:read(reg, amount)
         return nil
     end
     -- Stop and start, the wrong way, but I get no ACK from the slave when doing repeated start
-    i2c.stop(self.bus_id)
-    i2c.start(self.bus_id)
+    -- i2c.stop(self.bus_id)
+    -- i2c.start(self.bus_id)
     -- Repeated start, the correct way to do this
-    --i2c.start(self.bus_id)
+    i2c.start(self.bus_id)
     -- I suppose the direction here will set the R/W bit in the address, the eLua documentation is not 100% clear on this.
     local acked = i2c.address(self.bus_id, self.address, i2c.RECEIVER)
     if (not acked)

--- a/romfs/i2cdevice.lua
+++ b/romfs/i2cdevice.lua
@@ -1,0 +1,292 @@
+--[[--
+Helper baseclass for interfacing with I2C devices, you can use it as is,
+but much better idea is to subclass it for each device.
+
+This is basically port of my Arduino I2C device library: https://github.com/rambo/i2c_device
+
+Usage (without subclassing)
+
+i2cdev = require "i2cdevice"
+md = i2cdev.Device:new(0x1d)
+md:present() -- returns true/false depending on whether the slave ACKed or not
+md:dump_registers(0x0, 0x31) -- this will do a bunch of sequential single byte reads
+md:write(reg, value)
+md:read(reg, amount) -- amount is optional and defaults to 1
+md:read_modify_write(reg, mask, value, i2cdev.OR) -- the last param is optional and defaults to OR, C equivalent being: new_value = (old_value & mask) | given_value
+md:set_bit(reg, bitno, ...) -- just like bit.set can handle multiple positions in one call, these are probably much more handy than the old read_modify_write method above
+md:clear_bit(reg, bitno, ...) -- just like bit.set can handle multiple positions in one call
+
+
+For usage with subclassing see the mma8652fc module
+
+--]]--
+local i2cdevmod = {}
+require "yaci"
+
+i2cdevmod.debug = true
+
+-- judging by platform_i2c.c I2C1 (which is the only one on RuuviTracker) is the one to use and it's the zero key in the map...
+i2cdevmod.default_bus = 0
+i2cdevmod.default_speed = i2c.FAST
+i2cdevmod.pullups = {}
+-- Pins for I2C1 on revc1 (must be defined like this since Lua for some reason indexes arrays starting from 1 instead of 0 like every other language...)
+i2cdevmod.pullups[0] = { pio.PB_6,  pio.PB_7 }
+
+-- Constants for read-modify-write operations
+i2cdevmod.AND = 0
+i2cdevmod.OR  = 1
+i2cdevmod.XOR = 2
+
+-- Checks the input type and casts to number, string inputs are supposed to be in hexadecimal
+local function number_cast(inval)
+    if (type(inval) == "string")
+    then
+        return tonumber(inval, 16)
+    end
+    return inval
+end
+
+-- Enable pull-ups (if defined) for given bus-id, returns tue/false depending on whether pull-ups were defined
+local function enable_pullups(bus_id)
+    if (i2cdevmod.pullups[self.bus_id])
+    then
+        for i,pin in ipairs(i2cdevmod.pullups[bus_id])
+        do
+             pio.pin.setpull(pio.PULLUP, pin)
+        end
+        return true
+    end
+    return false
+end
+
+
+
+local Device = Object:subclass("Device")
+-- Constructor, takes device address (7-bit!) and optionally bus-id, string typed addresses are supposed to be in hexadecimal
+function Device:init(address, bus_id, bus_speed)
+    self.address = number_cast(address)
+    if (self.address > 127)
+    then
+        error("Use 7-bit address")
+    end
+    if (bus_id == nil)
+    then
+        self.bus_id = i2cdevmod.default_bus
+    else
+        self.bus_id = bus_id
+    end
+    if (bus_speed == nil)
+    then
+        self.bus_speed = i2cdevmod.default_speed
+    else
+        self.bus_speed = bus_speed
+    end
+    self:bus_init()
+end
+
+-- Re-initialize the I2C bus just in case you need to switch speeds or something
+function Device:bus_init()
+    i2c.setup(self.bus_id, self.bus_speed)
+end
+
+-- Reads amount bytes from register reg
+-- returns the data read as i2c.read returns it (use data:byte(index) to get the actual byte values, remember that Lua indices start from 1)
+-- Reading more than one byte at a time (at least from the onboard accelerometer) seems to hang eLua...
+function Device:read(reg, amount)
+    local bus_id = amount or 1 
+    reg = number_cast(reg)
+    -- TODO: this might throw an error (or it might not, documentation is not clear), catch it...
+    i2c.start(self.bus_id)
+    -- I suppose the direction here will set the R/W bit in the address, the eLua documentation is not 100% clear on this.
+    local acked = i2c.address(self.bus_id, self.address, i2c.TRANSMITTER)
+    if (not acked)
+    then
+        -- No such address, abort
+        if (i2cdevmod.debug)
+        then
+            print(string.format("ERROR: dev 0x%02x did not ACK in TRANSMITTER mode", self.address))
+        end
+        i2c.stop(self.bus_id)
+        return nil
+    end
+    local wrote = i2c.write(self.bus_id, reg)
+    if (not(wrote == 1))
+    then
+        -- Something went wrong, abort
+        if (i2cdevmod.debug)
+        then
+            print(string.format("ERROR: dev 0x%02x writing 0x%02x returned %d", self.address, reg, wrote))
+        end
+        i2c.stop(self.bus_id)
+        return nil
+    end
+    -- Stop and start, the wrong way, but I get no ACK from the slave when doing repeated start
+    i2c.stop(self.bus_id)
+    i2c.start(self.bus_id)
+    -- Repeated start, the correct way to do this
+    --i2c.start(self.bus_id)
+    -- I suppose the direction here will set the R/W bit in the address, the eLua documentation is not 100% clear on this.
+    local acked = i2c.address(self.bus_id, self.address, i2c.RECEIVER)
+    if (not acked)
+    then
+        -- Just in case the device went away at this point
+        if (i2cdevmod.debug)
+        then
+            print(string.format("ERROR: dev 0x%02x did not ACK in RECEIVER mode", self.address))
+        end
+        i2c.stop(self.bus_id)
+        return nil
+    end
+    local data = i2c.read(self.bus_id, amount)
+    i2c.stop(self.bus_id)
+    -- Remember to use data:byte(index) to get the actual byte value 
+    return data
+end
+
+-- Writes to register reg, takes N data arguments just like i2c.write
+-- returns the number of data bytes sent (the register is not in this count)
+function Device:write(reg, ...)
+    local reg = number_cast(reg)
+    -- TODO: this might throw an error (or it might not, documentation is not clear), catch it...
+    i2c.start(self.bus_id)
+    -- I suppose the direction here will set the R/W bit in the address, the eLua documentation is not 100% clear on this.
+    local acked = i2c.address(self.bus_id, self.address, i2c.TRANSMITTER)
+    if (not acked)
+    then
+        -- No such address, abort
+        if (i2cdevmod.debug)
+        then
+            print(string.format("ERROR: dev 0x%02x did not ACK in TRANSMITTER mode", self.address))
+        end
+        i2c.stop(self.bus_id)
+        return nil
+    end
+    -- First write just the register
+    local wrote = i2c.write(self.bus_id, reg)
+    if (not(wrote == 1))
+    then
+        -- Something went wrong, abort
+        if (i2cdevmod.debug)
+        then
+            print(string.format("ERROR: dev 0x%02x writing 0x%02x returned %d", self.address, reg, wrote))
+        end
+        i2c.stop(self.bus_id)
+        return nil
+    end
+    -- then the rest of it
+    local wrote = i2c.write(self.bus_id, unpack(arg))
+    i2c.stop(self.bus_id)
+    return wrote
+end
+
+-- Dumps the contents of given register range one-by-one
+-- Does this naively just in case register address auto-increment is not enabled/supported on the device
+function Device:dump_registers(start_reg, end_reg)
+    for reg=start_reg,end_reg
+    do
+        local value = self:read(reg, 1)
+        if (value == nil)
+        then
+            print(string.format("dev 0x%02x reg 0x%02x READ FAILED", self.address, reg))
+        else
+            -- Unfortunately there is no built-bin number->binary string formatter or even a helper function
+            print(string.format("dev 0x%02x reg 0x%02x value 0x%02x", self.address, reg, value:byte(1))) -- Remember Lua indices start from 1 (http://www.youtube.com/watch?v=IuGjtlsKo4s#t=13)
+        end
+    end
+end
+
+-- Do a masked read-modify-write, to twiddle register bits
+-- Returns the new value, or nil in case of trouble
+function Device:read_modify_write(reg, mask, value, operand)
+    local operand = operand or i2cdevmod.OR
+    local reg_value = self:read(reg, 1)
+    if (ref_value == nil)
+    then
+        return nil
+    end
+    local reg_new_value = reg_value
+    if (openrand == i2cdevmod.OR)
+    then
+        new_value = bit.bor(bit.band(value, mask), value)
+    end
+    if (openrand == i2cdevmod.AND)
+    then
+        new_value = bit.band(bit.band(value, mask), value)
+    end
+    if (openrand == i2cdevmod.XOR)
+    then
+        new_value = bit.bxor(bit.band(value, mask), value)
+    end
+    local wrote self:write(reg, reg_new_value)
+    if (wrote == nil)
+    then
+        return nil
+    end
+    return reg_new_value
+end
+
+-- Wrapper for bit.set to do the operation on a device register
+-- Returns the new value, or nil in case of trouble
+function Device:set_bit(reg, ...)
+    local reg_value = self:read(reg, 1)
+    if (ref_value == nil)
+    then
+        return nil
+    end
+    local reg_new_value = bit.set(reg_value, unpack(arg))
+    local wrote self:write(reg, reg_new_value)
+    if (wrote == nil)
+    then
+        return nil
+    end
+    return reg_new_value
+end
+
+-- Wrapper for bit.clear to do the operation on a device register
+-- Returns the new value, or nil in case of trouble
+function Device:clear_bit(reg, ...)
+    local reg_value = self:read(reg, 1)
+    if (ref_value == nil)
+    then
+        return nil
+    end
+    local reg_new_value = bit.clear(reg_value, unpack(arg))
+    local wrote self:write(reg, reg_new_value)
+    if (wrote == nil)
+    then
+        return nil
+    end
+    return reg_new_value
+end
+
+-- Check ACK from the device.
+function Device:present()
+    i2c.start(self.bus_id)
+    local acked = i2c.address(self.bus_id, self.address, i2c.RECEIVER)
+    i2c.stop(self.bus_id)
+    return acked
+end
+
+i2cdevmod.Device = Device
+
+-- Address space scan helper
+function i2cdevmod.address_scan(bus_id, bus_speed)
+    -- this works for numbers, but if we need to distinguish between false and nil we need a different approach
+    local bus_id = bus_id or i2cdevmod.default_bus 
+    local bus_speed = bus_speed or i2cdevmod.default_speed
+    local speed = i2c.setup(bus_id, bus_speed)
+    print(string.format("Scanning bus %d at speed %s", bus_id, speed))
+    for addr=0,127
+    do
+        i2c.start(bus_id)
+        local acked = i2c.address(bus_id, addr, i2c.RECEIVER)
+        if (acked)
+        then
+            print(string.format("FOUND device 0x%02x", addr))
+        end
+        i2c.stop(bus_id)
+    end
+end
+
+
+return i2cdevmod

--- a/romfs/i2cdevice.lua
+++ b/romfs/i2cdevice.lua
@@ -7,6 +7,7 @@ This is basically port of my Arduino I2C device library: https://github.com/ramb
 Usage (without subclassing)
 
 i2cdev = require "i2cdevice"
+i2cdev.address_scan() -- Runs a scan for the 7-bit address space
 md = i2cdev.Device:new(0x1d)
 md:present() -- returns true/false depending on whether the slave ACKed or not
 md:dump_registers(0x0, 0x31) -- this will do a bunch of sequential single byte reads

--- a/romfs/yaci.lua
+++ b/romfs/yaci.lua
@@ -1,0 +1,229 @@
+-----------------------------------------------------------------------------------
+-- Yet Another Class Implementation (version 1.2)
+-- From https://github.com/jpatte/yaci.lua
+--
+-- Julien Patte [julien.patte AT gmail DOT com] - 25 Feb 2007
+--
+-- Inspired from code written by Kevin Baca, Sam Lie, Christian Lindig and others
+-- Thanks to Damian Stewart and Frederic Thomas for their interest and comments
+-----------------------------------------------------------------------------------
+
+do	-- keep local things inside
+
+-- associations between an object an its meta-informations
+-- e.g its class, its "lower" object (if any), ...
+local metaObj = {}
+setmetatable(metaObj, {__mode = "k"})
+
+-----------------------------------------------------------------------------------
+-- internal function 'duplicate'
+-- return a shallow copy of table t
+
+local function duplicate(t)
+  t2 = {}
+  for k,v in pairs(t) do t2[k] = v end
+  return t2
+end
+	
+-----------------------------------------------------------------------------------
+-- internal function 'newInstance'
+
+local function newInstance(class, ...) 
+
+  local function makeInstance(class, virtuals)
+    local inst = duplicate(virtuals)
+    metaObj[inst] = { obj = inst, class = class }
+  
+    if class:super()~=nil then
+      inst.super = makeInstance(class:super(), virtuals)
+      metaObj[inst].super = metaObj[inst.super]	-- meta-info about inst
+      metaObj[inst.super].lower = metaObj[inst]
+    else 
+      inst.super = {}
+    end 
+  
+    setmetatable(inst, class.static)
+  
+    return inst
+  end
+ 
+  local inst = makeInstance(class, metaObj[class].virtuals) 
+  inst:init(unpack(arg))
+  return inst
+end
+
+-----------------------------------------------------------------------------------
+-- internal function 'makeVirtual'
+
+local function makeVirtual(class, fname) 
+  local func = class.static[fname]
+  if func == nil then 
+    func = function() error("Attempt to call an undefined abstract method '"..fname.."'") end
+   end
+  metaObj[class].virtuals[fname] = func
+end
+
+-----------------------------------------------------------------------------------
+-- internal function 'trycast'
+-- try to cast an instance into an instance of one of its super- or subclasses
+
+local function tryCast(class, inst) 
+  local meta = metaObj[inst]
+  if meta.class==class then return inst end -- is it already the right class?
+  
+  while meta~=nil do	-- search lower in the hierarchy
+    if meta.class==class then return meta.obj end
+    meta = meta.lower
+  end
+  
+  meta = metaObj[inst].super  -- not found, search through the superclasses
+  while meta~=nil do	
+    if meta.class==class then return meta.obj end
+    meta = meta.super
+  end
+  
+  return nil -- could not execute casting
+end
+
+-----------------------------------------------------------------------------------
+-- internal function 'secureCast'
+-- same as trycast but raise an error in case of failure
+
+local function secureCast(class, inst) 
+  local casted = tryCast(class, inst)
+  if casted == nil then 
+	error("Failed to cast " .. tostring(inst) .. " to a " .. class:name())
+  end
+  return casted
+end
+
+-----------------------------------------------------------------------------------
+-- internal function 'classMade'
+
+local function classMade(class, obj) 
+  if metaObj[obj]==nil then return false end -- is this really an object?
+  return (tryCast(class,obj) ~= nil) -- check if that class could cast the object
+end
+
+
+-----------------------------------------------------------------------------------
+-- internal function 'callup'
+-- Function used to transfer a method call from a class to its superclass
+
+local callup_inst
+local callup_target
+
+local function callup(inst, ...)
+  return callup_target(callup_inst, unpack(arg))	-- call the superclass' method
+end
+
+
+-----------------------------------------------------------------------------------
+-- internal function 'subclass'
+
+local function inst_init_def(inst,...) 
+  inst.super:init() 
+end
+
+local function inst_newindex(inst,key,value)							
+  if inst.super[key] ~= nil then 	-- First check if this field isn't already
+									-- defined higher in the hierarchy
+	inst.super[key] = value;		-- Update the old value
+  else 
+  	rawset(inst,key,value); 		-- Create the field
+  end
+end
+
+local function subclass(baseClass, name) 
+  if type(name)~="string" then name = "Unnamed" end
+  
+  local theClass = {}
+
+	-- need to copy everything here because events can't be found through metatables
+  local b = baseClass.static
+  local inst_stuff = { __tostring=b.__tostring, __eq=b.__eq, __add=b.__add, __sub=b.__sub, 
+	__mul=b.__mul, __div=b.__div, __mod=b.__mod, __pow=b.__pow, __unm=b.__unm, 
+	__len=b.__len, __lt=b.__lt, __le=b.__le, __concat=b.__concat, __call=b.__call}
+ 
+  inst_stuff.init = inst_init_def
+  inst_stuff.__newindex = inst_newindex
+  function inst_stuff.class() return theClass end
+
+  function inst_stuff.__index(inst, key) -- Look for field 'key' in instance 'inst'
+	local res = inst_stuff[key] 		-- Is it present?
+	if res~=nil then return res end		-- Okay, return it
+	
+	res = inst.super[key]  				-- Is it somewhere higher in the hierarchy?
+	
+	if type(res)=='function' and
+		res ~= callup then 				-- If it is a method of the superclass,
+		callup_inst = inst.super  		-- we will need to do a special forwarding
+		callup_target = res  			-- to call 'res' with the correct 'self'
+		return callup 					-- The 'callup' function will do that
+	end
+	
+	return res
+  end
+ 
+
+  local class_stuff = { static = inst_stuff, made = classMade, new = newInstance,
+	subclass = subclass, virtual = makeVirtual, cast = secureCast, trycast = tryCast }
+  metaObj[theClass] = { virtuals = duplicate(metaObj[baseClass].virtuals) }
+  
+  function class_stuff.name(class) return name end
+  function class_stuff.super(class) return baseClass end
+  function class_stuff.inherits(class, other) 
+	return (baseClass==other or baseClass:inherits(other)) 
+  end
+ 
+  local function newmethod(class, name, meth)
+	inst_stuff[name] = meth;
+	if metaObj[class].virtuals[name]~=nil then 
+		metaObj[class].virtuals[name] = meth	
+	end
+  end
+  
+  local function tos() return ("class "..name) end
+  setmetatable(theClass, { __newindex = newmethod, __index = class_stuff, 
+	__tostring = tos, __call = newInstance } )
+ 
+  return theClass
+end
+
+-----------------------------------------------------------------------------------
+-- The 'Object' class
+
+Object = {}
+
+local function obj_newitem() error "May not modify the class 'Object'. Subclass it instead." end
+local obj_inst_stuff = {}
+function obj_inst_stuff.init(inst,...) end
+obj_inst_stuff.__index = obj_inst_stuff
+obj_inst_stuff.__newindex = obj_newitem
+function obj_inst_stuff.class() return Object end
+function obj_inst_stuff.__tostring(inst) return ("a "..inst:class():name()) end
+
+local obj_class_stuff = { static = obj_inst_stuff, made = classMade, new = newInstance,
+	subclass = subclass, cast = secureCast, trycast = tryCast }
+function obj_class_stuff.name(class) return "Object" end
+function obj_class_stuff.super(class) return nil end
+function obj_class_stuff.inherits(class, other) return false end
+metaObj[Object] = { virtuals={} }
+
+local function tos() return ("class Object") end
+setmetatable(Object, { __newindex = obj_newitem, __index = obj_class_stuff, 
+	__tostring = tos, __call = newInstance } )
+
+----------------------------------------------------------------------
+-- function 'newclass'
+
+function newclass(name, baseClass)
+ baseClass = baseClass or Object
+ return baseClass:subclass(name)
+end
+
+end -- 2 global things remain: 'Object' and 'newclass'
+
+-- end of code
+
+

--- a/src/modules/i2c.c
+++ b/src/modules/i2c.c
@@ -79,7 +79,20 @@ static int i2c_address( lua_State *L )
 	MOD_CHECK_ID( i2c, id );
 	if ( address < 0 || address > 127 )
 		return luaL_error( L, "slave address must be from 0 to 127" );
-	lua_pushboolean( L, platform_i2c_send_address( id, (u16)address, direction ) );
+	rt_error status = platform_i2c_send_address( id, (u16)address, direction );
+	switch(status)
+	{
+		case RT_ERR_OK:
+			break;
+		case RT_ERR_TIMEOUT:
+			return luaL_error( L, "Timeout when sending address" );
+			break;
+		default:
+		case RT_ERR_ERROR:
+			return luaL_error( L, "Unknown error when sending address" );
+			break;
+	}
+	lua_pushboolean( L, 1);
 	return 1;
 }
 

--- a/src/modules/i2c.c
+++ b/src/modules/i2c.c
@@ -83,6 +83,12 @@ static int i2c_address( lua_State *L )
 	switch(status)
 	{
 		case RT_ERR_OK:
+			lua_pushboolean( L, 1);
+			return 1;
+			break;
+		case RT_ERR_FAIL:
+			lua_pushboolean( L, 0);
+			return 1;
 			break;
 		case RT_ERR_TIMEOUT:
 			return luaL_error( L, "Timeout when sending address" );
@@ -92,8 +98,6 @@ static int i2c_address( lua_State *L )
 			return luaL_error( L, "Unknown error when sending address" );
 			break;
 	}
-	lua_pushboolean( L, 1);
-	return 1;
 }
 
 // Lua: wrote = i2c.write( id, data1, [data2], ..., [datan] )

--- a/src/modules/i2c.c
+++ b/src/modules/i2c.c
@@ -59,11 +59,11 @@ static int i2c_stop( lua_State *L )
 		case RT_ERR_OK:
 			break;
 		case RT_ERR_TIMEOUT:
-			return luaL_error( L, "Timeout when sending start" );
+			return luaL_error( L, "Timeout when sending stop" );
 			break;
 		default:
 		case RT_ERR_ERROR:
-			return luaL_error( L, "Unknown error when sending start" );
+			return luaL_error( L, "Unknown error when sending stop" );
 			break;
 	}
 	return 0;

--- a/src/modules/i2c.c
+++ b/src/modules/i2c.c
@@ -173,7 +173,7 @@ static int i2c_read( lua_State *L )
 				break;
 			default:
 			case RT_ERR_ERROR:
-				return luaL_error( L, "Unknown error receiving data" );
+				return luaL_error( L, "Unknown error when receiving data" );
 				break;
 		}
 		luaL_addchar( &b, ( char )data );
@@ -210,7 +210,7 @@ static int _i2c_read_8_16(char width, lua_State *L )
 			break;
 		default:
 		case RT_ERR_ERROR:
-			return luaL_error( L, "Unknown from platform_i2c_read8/16 (actual subfunction unknown)" );
+			return luaL_error( L, "Unknown error from platform_i2c_read8/16 (actual subfunction unknown)" );
 			break;
 	}
 	if (0 == rc)

--- a/src/modules/i2c.c
+++ b/src/modules/i2c.c
@@ -31,7 +31,21 @@ static int i2c_start( lua_State *L )
 	unsigned id = luaL_checkinteger( L, 1 );
 
 	MOD_CHECK_ID( i2c, id );
-	platform_i2c_send_start( id );
+	rt_error status = platform_i2c_send_start( id );
+	switch(status)
+	{
+		case RT_ERR_OK:
+			break;
+		case RT_ERR_TIMEOUT:
+		{
+			return luaL_error( L, "Timeout when sending start" );
+			break;
+		}
+		default:
+		case RT_ERR_ERROR:
+			return luaL_error( L, "Unknown error when sending start" );
+			break;
+	}
 	return 0;
 }
 
@@ -41,7 +55,21 @@ static int i2c_stop( lua_State *L )
 	unsigned id = luaL_checkinteger( L, 1 );
 
 	MOD_CHECK_ID( i2c, id );
-	platform_i2c_send_stop( id );
+	rt_error status = platform_i2c_send_stop( id );
+	switch(status)
+	{
+		case RT_ERR_OK:
+			break;
+		case RT_ERR_TIMEOUT:
+		{
+			return luaL_error( L, "Timeout when sending start" );
+			break;
+		}
+		default:
+		case RT_ERR_ERROR:
+			return luaL_error( L, "Unknown error when sending start" );
+			break;
+	}
 	return 0;
 }
 

--- a/src/modules/i2c.c
+++ b/src/modules/i2c.c
@@ -106,6 +106,7 @@ static int i2c_write( lua_State *L )
 	int numdata;
 	u32 wrote = 0;
 	unsigned argn;
+	rt_error status;
 
 	MOD_CHECK_ID( i2c, id );
 	if( lua_gettop( L ) < 2 )
@@ -119,8 +120,19 @@ static int i2c_write( lua_State *L )
 			numdata = ( int )luaL_checkinteger( L, argn );
 			if( numdata < 0 || numdata > 255 )
 				return luaL_error( L, "numeric data must be from 0 to 255" );
-			if( platform_i2c_send_byte( id, numdata ) != 1 )
-				break;
+			status = platform_i2c_send_byte( id, numdata );
+			switch(status)
+			{
+				case RT_ERR_OK:
+					break;
+				case RT_ERR_TIMEOUT:
+					return luaL_error( L, "Timeout when sending data" );
+					break;
+				default:
+				case RT_ERR_ERROR:
+					return luaL_error( L, "Unknown error when sending data" );
+					break;
+			}
 			wrote ++;
 		}
 		else if( lua_istable( L, argn ) )
@@ -133,8 +145,19 @@ static int i2c_write( lua_State *L )
 				lua_pop( L, 1 );
 				if( numdata < 0 || numdata > 255 )
 					return luaL_error( L, "numeric data must be from 0 to 255" );
-				if( platform_i2c_send_byte( id, numdata ) == 0 )
-					break;
+				status = platform_i2c_send_byte( id, numdata );
+				switch(status)
+				{
+					case RT_ERR_OK:
+						break;
+					case RT_ERR_TIMEOUT:
+						return luaL_error( L, "Timeout when sending data" );
+						break;
+					default:
+					case RT_ERR_ERROR:
+						return luaL_error( L, "Unknown error when sending data" );
+						break;
+				}
 			}
 			wrote += i;
 			if( i < datalen )
@@ -145,8 +168,19 @@ static int i2c_write( lua_State *L )
 			pdata = luaL_checklstring( L, argn, &datalen );
 			for( i = 0; i < datalen; i ++ )
 			{
-				if( platform_i2c_send_byte( id, pdata[ i ] ) == 0 )
-					break;
+				status = platform_i2c_send_byte( id, pdata[ i ] );
+				switch(status)
+				{
+					case RT_ERR_OK:
+						break;
+					case RT_ERR_TIMEOUT:
+						return luaL_error( L, "Timeout when sending data" );
+						break;
+					default:
+					case RT_ERR_ERROR:
+						return luaL_error( L, "Unknown error when sending data" );
+						break;
+				}
 			}
 			wrote += i;
 			if( i < datalen )

--- a/src/modules/i2c.c
+++ b/src/modules/i2c.c
@@ -10,6 +10,8 @@
 #include <ctype.h>
 #include <stdlib.h>
 
+#include "ruuvi_errors.h"
+
 // Lua: speed = i2c.setup( id, speed )
 static int i2c_setup( lua_State *L )
 {

--- a/src/modules/i2c.c
+++ b/src/modules/i2c.c
@@ -206,11 +206,11 @@ static int _i2c_read_8_16(char width, lua_State *L )
 		case RT_ERR_OK:
 			break;
 		case RT_ERR_TIMEOUT:
-			return luaL_error( L, "Timeout when sending address" );
+			return luaL_error( L, "Timeout from platform_i2c_read8/16 (actual subfunction unknown)" );
 			break;
 		default:
 		case RT_ERR_ERROR:
-			return luaL_error( L, "Unknown error when sending address" );
+			return luaL_error( L, "Unknown from platform_i2c_read8/16 (actual subfunction unknown)" );
 			break;
 	}
 	if (0 == rc)
@@ -235,6 +235,7 @@ static int i2c_read_16(lua_State *L)
 static int _i2c_write_8_16(char width, lua_State *L )
 {
 	int ret;
+	rt_error status;
 	unsigned id = luaL_checkinteger(L, 1);
 	int dev     = luaL_checkinteger(L, 2);
 	int addr    = luaL_checkinteger(L, 3);
@@ -277,10 +278,22 @@ static int _i2c_write_8_16(char width, lua_State *L )
 		}
 	}
 	if (8 == width)
-		ret = platform_i2c_write8(id, dev, addr, buff, len);
+		status = platform_i2c_write8(id, dev, addr, buff, len, &ret);
 	else
-		ret = platform_i2c_write16(id, dev, addr, buff, len);
+		status = platform_i2c_write16(id, dev, addr, buff, len, &ret);
 	free(buff);
+	switch(status)
+	{
+		case RT_ERR_OK:
+			break;
+		case RT_ERR_TIMEOUT:
+			return luaL_error( L, "Timeout from platform_i2c_write8/16 (actual subfunction unknown)" );
+			break;
+		default:
+		case RT_ERR_ERROR:
+			return luaL_error( L, "Unknown error from platform_i2c_write8/16 (actual subfunction unknown)" );
+			break;
+	}
 	lua_pushinteger(L, ret);
 	return 1;
 }

--- a/src/modules/i2c.c
+++ b/src/modules/i2c.c
@@ -110,19 +110,24 @@ static int i2c_write( lua_State *L )
 	MOD_CHECK_ID( i2c, id );
 	if( lua_gettop( L ) < 2 )
 		return luaL_error( L, "invalid number of arguments" );
-	for( argn = 2; argn <= lua_gettop( L ); argn ++ ) {
+	for( argn = 2; argn <= lua_gettop( L ); argn ++ )
+	{
 		// lua_isnumber() would silently convert a string of digits to an integer
 		// whereas here strings are handled separately.
-		if( lua_type( L, argn ) == LUA_TNUMBER ) {
+		if( lua_type( L, argn ) == LUA_TNUMBER )
+		{
 			numdata = ( int )luaL_checkinteger( L, argn );
 			if( numdata < 0 || numdata > 255 )
 				return luaL_error( L, "numeric data must be from 0 to 255" );
 			if( platform_i2c_send_byte( id, numdata ) != 1 )
 				break;
 			wrote ++;
-		} else if( lua_istable( L, argn ) ) {
+		}
+		else if( lua_istable( L, argn ) )
+		{
 			datalen = lua_objlen( L, argn );
-			for( i = 0; i < datalen; i ++ ) {
+			for( i = 0; i < datalen; i ++ )
+			{
 				lua_rawgeti( L, argn, i + 1 );
 				numdata = ( int )luaL_checkinteger( L, -1 );
 				lua_pop( L, 1 );
@@ -134,11 +139,15 @@ static int i2c_write( lua_State *L )
 			wrote += i;
 			if( i < datalen )
 				break;
-		} else {
+		}
+		else
+		{
 			pdata = luaL_checklstring( L, argn, &datalen );
 			for( i = 0; i < datalen; i ++ )
+			{
 				if( platform_i2c_send_byte( id, pdata[ i ] ) == 0 )
 					break;
+			}
 			wrote += i;
 			if( i < datalen )
 				break;

--- a/src/modules/i2c.c
+++ b/src/modules/i2c.c
@@ -37,10 +37,8 @@ static int i2c_start( lua_State *L )
 		case RT_ERR_OK:
 			break;
 		case RT_ERR_TIMEOUT:
-		{
 			return luaL_error( L, "Timeout when sending start" );
 			break;
-		}
 		default:
 		case RT_ERR_ERROR:
 			return luaL_error( L, "Unknown error when sending start" );
@@ -61,10 +59,8 @@ static int i2c_stop( lua_State *L )
 		case RT_ERR_OK:
 			break;
 		case RT_ERR_TIMEOUT:
-		{
 			return luaL_error( L, "Timeout when sending start" );
 			break;
-		}
 		default:
 		case RT_ERR_ERROR:
 			return luaL_error( L, "Unknown error when sending start" );

--- a/src/platform/stm32f4/platform_conf.h
+++ b/src/platform/stm32f4/platform_conf.h
@@ -1,4 +1,5 @@
 // eLua platform configuration
+#define DEBUG
 
 #ifndef __PLATFORM_CONF_H__
 #define __PLATFORM_CONF_H__

--- a/src/platform/stm32f4/platform_conf.h
+++ b/src/platform/stm32f4/platform_conf.h
@@ -1,5 +1,4 @@
 // eLua platform configuration
-#define DEBUG
 
 #ifndef __PLATFORM_CONF_H__
 #define __PLATFORM_CONF_H__

--- a/src/platform/stm32f4/platform_i2c.c
+++ b/src/platform/stm32f4/platform_i2c.c
@@ -1,7 +1,7 @@
 #include "platform.h"
 #include "stm32f4xx_conf.h"
 #include <stm32f4xx.h>
-
+#include "ruuvi_errors.h"
 
 /* Definitions */
 I2C_TypeDef *const i2c[] = {I2C1, I2C2, I2C3};

--- a/src/platform/stm32f4/platform_i2c.c
+++ b/src/platform/stm32f4/platform_i2c.c
@@ -4,10 +4,16 @@
 #include <stm32f4xx.h>
 #include "ruuvi_errors.h"
 
+#ifdef DEBUG
 #include <stdio.h>
 #define D_ENTER() printf("%s:%s(): enter\n", __FILE__, __FUNCTION__)
 #define D_EXIT() printf("%s:%s(): exit\n", __FILE__, __FUNCTION__)
 #define _DEBUG(fmt, args...) printf("%s:%s:%d: "fmt, __FILE__, __FUNCTION__, __LINE__, args)
+#else
+#define D_ENTER()
+#define D_EXIT()
+#define _DEBUG(fmt, args...)
+#endif
 
 // Shorthand for checking for bus errors
 #define I2C_CHECK_BERR() if (I2C_GetFlagStatus(i2c[id], I2C_FLAG_BERR)) { _DEBUG("%s\n", "I2C bus error!"); D_EXIT(); return RT_ERR_ERROR; }

--- a/src/platform/stm32f4/platform_i2c.c
+++ b/src/platform/stm32f4/platform_i2c.c
@@ -131,12 +131,14 @@ rt_error platform_i2c_send_address( unsigned id, u16 address, int direction )
 	 */
 	if(direction == PLATFORM_I2C_DIRECTION_TRANSMITTER) {
 		I2C_Send7bitAddress(i2c[id], address, I2C_Direction_Transmitter);
+		// TODO: This cannot live with a NACK, so we need to do more complex flag checking
 		while(SUCCESS != I2C_CheckEvent(i2c[id], I2C_EVENT_MASTER_TRANSMITTER_MODE_SELECTED))
 		{
 			RT_TIMEOUT_CHECK( RT_DEFAULT_TIMEOUT );
 		}
 	} else if(direction == PLATFORM_I2C_DIRECTION_RECEIVER) {
 		I2C_Send7bitAddress(i2c[id], address, I2C_Direction_Receiver);
+		// TODO: This cannot live with a NACK, so we need to do more complex flag checking
 		while(SUCCESS != I2C_CheckEvent(i2c[id], I2C_EVENT_MASTER_RECEIVER_MODE_SELECTED))
 		{
 			RT_TIMEOUT_CHECK( RT_DEFAULT_TIMEOUT );

--- a/src/platform/stm32f4/platform_i2c.c
+++ b/src/platform/stm32f4/platform_i2c.c
@@ -192,9 +192,7 @@ static rt_error _i2c_recv_buf(unsigned id, u8 *buff, int len, int *recv_count)
 			ack = 0;
 		status = platform_i2c_recv_byte(id, ack, &buff[i]);
 		if (status != RT_ERR_OK)
-		{
 			return status;
-		}
 	}
 	*recv_count = i;
 	return RT_ERR_OK;
@@ -208,9 +206,7 @@ static rt_error _i2c_send_buf(unsigned id, u8 *buff, int len, int *send_count)
 	{
 		status = platform_i2c_send_byte(id, buff[i]);
 		if (status != RT_ERR_OK)
-		{
 			return status;
-		}
 	}
 	*send_count = i;
 	return RT_ERR_OK;
@@ -223,9 +219,7 @@ rt_error platform_i2c_read8(unsigned id, u8 device, u8 offset, u8 *buff, int len
 	rt_error status2;
 	status = platform_i2c_send_start(id);
 	if (status != RT_ERR_OK)
-	{
 		return status;
-	}
 	status = platform_i2c_send_address(id, device, PLATFORM_I2C_DIRECTION_TRANSMITTER);
 	if (status != RT_ERR_OK)
 		goto END;
@@ -248,13 +242,9 @@ rt_error platform_i2c_read8(unsigned id, u8 device, u8 offset, u8 *buff, int len
 END:
 	status2 = platform_i2c_send_stop(id);
 	if (status != RT_ERR_OK)
-	{
 		return status;
-	}
 	if (status2 != RT_ERR_OK)
-	{
 		return status2;
-	}
 	return RT_ERR_OK;
 }
 
@@ -265,9 +255,7 @@ rt_error platform_i2c_write8(unsigned id, u8 device, u8 offset, u8 *buff, int le
 	rt_error status2;
 	status = platform_i2c_send_start(id);
 	if (status != RT_ERR_OK)
-	{
 		return status;
-	}
 	status = platform_i2c_send_address(id, device, PLATFORM_I2C_DIRECTION_TRANSMITTER);
 	if (status != RT_ERR_OK)
 		goto END;
@@ -278,13 +266,9 @@ rt_error platform_i2c_write8(unsigned id, u8 device, u8 offset, u8 *buff, int le
 END:
 	status2 = platform_i2c_send_stop(id);
 	if (status != RT_ERR_OK)
-	{
 		return status;
-	}
 	if (status2 != RT_ERR_OK)
-	{
 		return status2;
-	}
 	return RT_ERR_OK;
 }
 
@@ -293,14 +277,10 @@ static rt_error _i2c_send_offset16(unsigned id, u8 offset)
 	rt_error status;
 	status = platform_i2c_send_byte(id, (offset>>8)&0xff);
 	if (status != RT_ERR_OK)
-	{
 		return status;
-	}
 	status = platform_i2c_send_byte(id, (offset&0xff));
 	if (status != RT_ERR_OK)
-	{
 		return status;
-	}
 	return RT_ERR_OK;
 }
 
@@ -311,9 +291,7 @@ rt_error platform_i2c_read16(unsigned id, u8 device, u16 offset, u8 *buff, int l
 	rt_error status2;
 	status = platform_i2c_send_start(id);
 	if (status != RT_ERR_OK)
-	{
 		return status;
-	}
 	status = platform_i2c_send_address(id, device, PLATFORM_I2C_DIRECTION_TRANSMITTER);
 	if (status != RT_ERR_OK)
 		goto END;
@@ -336,13 +314,9 @@ rt_error platform_i2c_read16(unsigned id, u8 device, u16 offset, u8 *buff, int l
 END:
 	status2 = platform_i2c_send_stop(id);
 	if (status != RT_ERR_OK)
-	{
 		return status;
-	}
 	if (status2 != RT_ERR_OK)
-	{
 		return status2;
-	}
 	return RT_ERR_OK;
 }
 
@@ -353,9 +327,7 @@ rt_error platform_i2c_write16(unsigned id, u8 device, u16 offset, u8 *buff, int 
 	rt_error status2;
 	status = platform_i2c_send_start(id);
 	if (status != RT_ERR_OK)
-	{
 		return status;
-	}
 	status = platform_i2c_send_address(id, device, PLATFORM_I2C_DIRECTION_TRANSMITTER);
 	if (status != RT_ERR_OK)
 		goto END;
@@ -366,12 +338,8 @@ rt_error platform_i2c_write16(unsigned id, u8 device, u16 offset, u8 *buff, int 
 END:
 	status2 = platform_i2c_send_stop(id);
 	if (status != RT_ERR_OK)
-	{
 		return status;
-	}
 	if (status2 != RT_ERR_OK)
-	{
 		return status2;
-	}
 	return RT_ERR_OK;
 }

--- a/src/platform/stm32f4/platform_i2c.c
+++ b/src/platform/stm32f4/platform_i2c.c
@@ -4,18 +4,10 @@
 #include <stm32f4xx.h>
 #include "ruuvi_errors.h"
 
-/*
-#ifdef DEBUG
 #include <stdio.h>
 #define D_ENTER() printf("%s:%s(): enter\n", __FILE__, __FUNCTION__)
 #define D_EXIT() printf("%s:%s(): exit\n", __FILE__, __FUNCTION__)
 #define _DEBUG(fmt, args...) printf("%s:%s:%d: "fmt, __FILE__, __FUNCTION__, __LINE__, args)
-#else
-*/
-#define D_ENTER()
-#define D_EXIT()
-#define _DEBUG(fmt, args...)
-//#endif
 
 // Shorthand for checking for bus errors
 #define I2C_CHECK_BERR() if (I2C_GetFlagStatus(i2c[id], I2C_FLAG_BERR)) { _DEBUG("%s\n", "I2C bus error!"); D_EXIT(); return RT_ERR_ERROR; }

--- a/src/platform/stm32f4/platform_i2c.c
+++ b/src/platform/stm32f4/platform_i2c.c
@@ -183,12 +183,14 @@ rt_error platform_i2c_recv_byte( unsigned id, int ack, u8 *buff)
 static rt_error _i2c_recv_buf(unsigned id, u8 *buff, int len, int *recv_count)
 {
 	int i, ack;
-	for (i=0;i<len;i++) {
+	rt_error status;
+	for (i=0;i<len;i++)
+	{
 		if (i<(len-1))
 			ack = 1;
 		else
 			ack = 0;
-		rt_error status = platform_i2c_recv_byte(id, ack, &buff[i]);
+		status = platform_i2c_recv_byte(id, ack, &buff[i]);
 		if (status != RT_ERR_OK)
 		{
 			return status;

--- a/src/platform/stm32f4/platform_i2c.c
+++ b/src/platform/stm32f4/platform_i2c.c
@@ -81,24 +81,33 @@ u32 platform_i2c_setup( unsigned id, u32 speed )
 	return speed;
 }
 
-void platform_i2c_send_start( unsigned id )
+rt_error platform_i2c_send_start( unsigned id )
 {
-	int timeout = TIMEOUT;
+	RT_TIMEOUT_INIT();
 	// wait until I2C1 is not busy anymore
-	while(I2C_GetFlagStatus(i2c[id], I2C_FLAG_BUSY)) {
-		if (timeout-- == 0) {
-			return;
-		}
+	while(I2C_GetFlagStatus(i2c[id], I2C_FLAG_BUSY))
+	{
+		RT_TIMEOUT_CHECK( RT_DEFAULT_TIMEOUT );
 	}
 
 	// Send I2C1 START condition
 	I2C_GenerateSTART(i2c[id], ENABLE);
+	return RT_ERR_OK;
 }
 
-void platform_i2c_send_stop( unsigned id )
+rt_error platform_i2c_send_stop( unsigned id )
 {
+	RT_TIMEOUT_INIT();
+	// wait until I2C1 is not busy anymore
+	while(I2C_GetFlagStatus(i2c[id], I2C_FLAG_BUSY))
+	{
+		RT_TIMEOUT_CHECK( RT_DEFAULT_TIMEOUT );
+	}
+
 	// Send I2C1 STOP Condition
 	I2C_GenerateSTOP(i2c[id], ENABLE);
+
+	return RT_ERR_OK;
 }
 
 /* Send 7bit address to I2C buss */

--- a/src/platform/stm32f4/platform_i2c.c
+++ b/src/platform/stm32f4/platform_i2c.c
@@ -112,18 +112,17 @@ rt_error platform_i2c_send_stop( unsigned id )
 
 /* Send 7bit address to I2C buss */
 /* Adds R/W bit to end of address.(Should not be included in address) */
-int platform_i2c_send_address( unsigned id, u16 address, int direction )
+rt_error platform_i2c_send_address( unsigned id, u16 address, int direction )
 {
-	int timeout = TIMEOUT;
+	RT_TIMEOUT_INIT();
 	// wait for I2C1 EV5 --> Master has acknowledged start condition
-	while(SUCCESS != I2C_CheckEvent(i2c[id], I2C_EVENT_MASTER_MODE_SELECT)) {
-		if (timeout-- == 0) {
-			return 0;
-		}
+	while(SUCCESS != I2C_CheckEvent(i2c[id], I2C_EVENT_MASTER_MODE_SELECT))
+	{
+		RT_TIMEOUT_CHECK( RT_DEFAULT_TIMEOUT );
 	}
 
 	address<<=1; //Shift 7bit address to left by one to leave room for R/W bit
-	timeout = TIMEOUT;
+	RT_TIMEOUT_REINIT();
 
 	/* wait for I2C1 EV6, check if
 	 * either Slave has acknowledged Master transmitter or
@@ -132,20 +131,18 @@ int platform_i2c_send_address( unsigned id, u16 address, int direction )
 	 */
 	if(direction == PLATFORM_I2C_DIRECTION_TRANSMITTER) {
 		I2C_Send7bitAddress(i2c[id], address, I2C_Direction_Transmitter);
-		while(SUCCESS != I2C_CheckEvent(i2c[id], I2C_EVENT_MASTER_TRANSMITTER_MODE_SELECTED)) {
-			if (timeout-- == 0) {
-				return 0;
-			}
+		while(SUCCESS != I2C_CheckEvent(i2c[id], I2C_EVENT_MASTER_TRANSMITTER_MODE_SELECTED))
+		{
+			RT_TIMEOUT_CHECK( RT_DEFAULT_TIMEOUT );
 		}
 	} else if(direction == PLATFORM_I2C_DIRECTION_RECEIVER) {
 		I2C_Send7bitAddress(i2c[id], address, I2C_Direction_Receiver);
-		while(SUCCESS != I2C_CheckEvent(i2c[id], I2C_EVENT_MASTER_RECEIVER_MODE_SELECTED)) {
-			if (timeout-- == 0) {
-				return 0;
-			}
+		while(SUCCESS != I2C_CheckEvent(i2c[id], I2C_EVENT_MASTER_RECEIVER_MODE_SELECTED))
+		{
+			RT_TIMEOUT_CHECK( RT_DEFAULT_TIMEOUT );
 		}
 	}
-	return 1;
+	return RT_ERR_OK;
 }
 
 /* Send one byte to I2C bus */

--- a/src/platform/stm32f4/platform_i2c.c
+++ b/src/platform/stm32f4/platform_i2c.c
@@ -4,16 +4,18 @@
 #include <stm32f4xx.h>
 #include "ruuvi_errors.h"
 
+/*
 #ifdef DEBUG
 #include <stdio.h>
 #define D_ENTER() printf("%s:%s(): enter\n", __FILE__, __FUNCTION__)
 #define D_EXIT() printf("%s:%s(): exit\n", __FILE__, __FUNCTION__)
 #define _DEBUG(fmt, args...) printf("%s:%s:%d: "fmt, __FILE__, __FUNCTION__, __LINE__, args)
 #else
+*/
 #define D_ENTER()
 #define D_EXIT()
 #define _DEBUG(fmt, args...)
-#endif
+//#endif
 
 // Shorthand for checking for bus errors
 #define I2C_CHECK_BERR() if (I2C_GetFlagStatus(i2c[id], I2C_FLAG_BERR)) { _DEBUG("%s\n", "I2C bus error!"); D_EXIT(); return RT_ERR_ERROR; }

--- a/src/platform/stm32f4/platform_i2c.c
+++ b/src/platform/stm32f4/platform_i2c.c
@@ -100,7 +100,7 @@ u32 platform_i2c_setup( unsigned id, u32 speed )
 
 rt_error platform_i2c_send_start( unsigned id )
 {
-	D_ENTER();
+	//D_ENTER();
 	RT_TIMEOUT_INIT();
 	// Wait for bus to become free (or that we are the master)
 	while(1)
@@ -117,12 +117,12 @@ rt_error platform_i2c_send_start( unsigned id )
 		}
 		RT_TIMEOUT_CHECK( RT_DEFAULT_TIMEOUT );
 	}
-	_DEBUG("%s\n", "bus free check passed");
+	//_DEBUG("%s\n", "bus free check passed");
 
-	RT_TIMEOUT_REINIT();
 	// Send I2C1 START condition
 	I2C_GenerateSTART(i2c[id], ENABLE);
 	// Wait for the start generation to complete
+	RT_TIMEOUT_REINIT();
 	while(!I2C_GetFlagStatus(i2c[id], I2C_FLAG_SB))
 	{
 		I2C_CHECK_BERR();
@@ -131,14 +131,14 @@ rt_error platform_i2c_send_start( unsigned id )
 	// Make sure there is no leftover NACK bit laying around...
 	//_DEBUG("start generated, status reg value=%x\n", (unsigned int)I2C_GetLastEvent(i2c[id]));
 	I2C_ClearFlag(i2c[id], I2C_FLAG_AF);
-	_DEBUG("start generated (NACK cleared), status reg value=%x\n", (unsigned int)I2C_GetLastEvent(i2c[id]));
-	D_EXIT();
+	//_DEBUG("start generated (NACK cleared), status reg value=%x\n", (unsigned int)I2C_GetLastEvent(i2c[id]));
+	//D_EXIT();
 	return RT_ERR_OK;
 }
 
 rt_error platform_i2c_send_stop( unsigned id )
 {
-	D_ENTER();
+	//D_ENTER();
 	RT_TIMEOUT_INIT();
 	// wait for the bus to be free for us to send that stop
 	while(1)
@@ -155,23 +155,23 @@ rt_error platform_i2c_send_stop( unsigned id )
 		}
 		RT_TIMEOUT_CHECK( RT_DEFAULT_TIMEOUT );
 	}
-	_DEBUG("%s\n", "bus free check passed");
+	//_DEBUG("%s\n", "bus free check passed");
 
-	RT_TIMEOUT_REINIT();
 	// Send I2C1 STOP Condition
 	I2C_GenerateSTOP(i2c[id], ENABLE);
 	// And wait for the STOP condition to complete and the bus to become free
+	RT_TIMEOUT_REINIT();
 	while(I2C_GetFlagStatus(i2c[id], I2C_FLAG_BUSY))
 	{
-		_DEBUG("waiting for bus, status reg value=%x\n", (unsigned int)I2C_GetLastEvent(i2c[id]));
+		//_DEBUG("waiting for bus, status reg value=%x\n", (unsigned int)I2C_GetLastEvent(i2c[id]));
 		I2C_CHECK_BERR();
 		RT_TIMEOUT_CHECK( RT_DEFAULT_TIMEOUT );
 	}
 	// Interestingly enough the bit NACK is not cleared by STOP condition even though documentation claims otherwise...
 	//_DEBUG("bus freed, status reg value=%x\n", (unsigned int)I2C_GetLastEvent(i2c[id]));
 	I2C_ClearFlag(i2c[id], I2C_FLAG_AF);
-	_DEBUG("bus freed (NACK cleared), status reg value=%x\n", (unsigned int)I2C_GetLastEvent(i2c[id]));
-	D_EXIT();
+	//_DEBUG("bus freed (NACK cleared), status reg value=%x\n", (unsigned int)I2C_GetLastEvent(i2c[id]));
+	//D_EXIT();
 	return RT_ERR_OK;
 }
 
@@ -179,8 +179,8 @@ rt_error platform_i2c_send_stop( unsigned id )
 /* Adds R/W bit to end of address.(Should not be included in address) */
 rt_error platform_i2c_send_address( unsigned id, u16 address, int direction )
 {
-	D_ENTER();
-	_DEBUG("address=0x%x\n", address);
+	//D_ENTER();
+	//_DEBUG("address=0x%x\n", address);
 	RT_TIMEOUT_INIT();
 	// wait for I2C1 EV5 --> Master has acknowledged start condition
 	while(SUCCESS != I2C_CheckEvent(i2c[id], I2C_EVENT_MASTER_MODE_SELECT))
@@ -188,7 +188,7 @@ rt_error platform_i2c_send_address( unsigned id, u16 address, int direction )
 		I2C_CHECK_BERR();
 		RT_TIMEOUT_CHECK( RT_DEFAULT_TIMEOUT );
 	}
-	_DEBUG("%s\n", "I2C_EVENT_MASTER_MODE_SELECT check passed");
+	//_DEBUG("%s\n", "I2C_EVENT_MASTER_MODE_SELECT check passed");
 
 	address<<=1; //Shift 7bit address to left by one to leave room for R/W bit
 	RT_TIMEOUT_REINIT();
@@ -203,23 +203,29 @@ rt_error platform_i2c_send_address( unsigned id, u16 address, int direction )
 		I2C_Send7bitAddress(i2c[id], address, I2C_Direction_Transmitter);
 		while(1)
 		{
-			_DEBUG("I2C_Direction_Transmitter, status reg value=%x\n", (unsigned int)I2C_GetLastEvent(i2c[id]));
+			//_DEBUG("I2C_Direction_Transmitter, status reg value=%x\n", (unsigned int)I2C_GetLastEvent(i2c[id]));
 			I2C_CHECK_BERR();
+			RT_TIMEOUT_CHECK( RT_DEFAULT_TIMEOUT );
+			// Do not check any othet flags before we have either NACK or ADDR flag up
+			if (   !I2C_GetFlagStatus(i2c[id], I2C_FLAG_AF)
+				&& !I2C_GetFlagStatus(i2c[id], I2C_FLAG_ADDR))
+			{
+				continue;
+			}
 			if (I2C_GetFlagStatus(i2c[id], I2C_FLAG_AF))
 			{
 				// NACK
-				_DEBUG("NACK for address=0x%x\n", address);
-				D_EXIT();
+				//_DEBUG("NACK for address=0x%x\n", address);
+				//D_EXIT();
 				return RT_ERR_FAIL;
 			}
 			if (I2C_GetFlagStatus(i2c[id], I2C_EVENT_MASTER_TRANSMITTER_MODE_SELECTED))
 			{
 				// ACK
-				_DEBUG("ACK for address=0x%x\n", address);
-				D_EXIT();
+				//_DEBUG("ACK for address=0x%x\n", address);
+				//D_EXIT();
 				return RT_ERR_OK;
 			}
-			RT_TIMEOUT_CHECK( RT_DEFAULT_TIMEOUT );
 		}
 	}
 	else if(direction == PLATFORM_I2C_DIRECTION_RECEIVER)
@@ -227,51 +233,58 @@ rt_error platform_i2c_send_address( unsigned id, u16 address, int direction )
 		I2C_Send7bitAddress(i2c[id], address, I2C_Direction_Receiver);
 		while(1)
 		{
-			_DEBUG("I2C_Direction_Receiver, status reg value=%x\n", (unsigned int)I2C_GetLastEvent(i2c[id]));
+			//_DEBUG("I2C_Direction_Receiver, status reg value=%x\n", (unsigned int)I2C_GetLastEvent(i2c[id]));
 			I2C_CHECK_BERR();
+			RT_TIMEOUT_CHECK( RT_DEFAULT_TIMEOUT );
+			// Do not check any othet flags before we have either NACK or ADDR flag up
+			if (   !I2C_GetFlagStatus(i2c[id], I2C_FLAG_AF)
+				&& !I2C_GetFlagStatus(i2c[id], I2C_FLAG_ADDR))
+			{
+				continue;
+			}
 			if (I2C_GetFlagStatus(i2c[id], I2C_FLAG_AF))
 			{
 				// NACK
-				_DEBUG("NACK for address=0x%x\n", (uint8_t)(address | 0x1));
+				//_DEBUG("NACK for address=0x%x\n", (uint8_t)(address | 0x1));
+				//D_EXIT();
 				return RT_ERR_FAIL;
 			}
 			if (I2C_GetFlagStatus(i2c[id], I2C_EVENT_MASTER_RECEIVER_MODE_SELECTED))
 			{
 				// ACK
-				_DEBUG("ACK for address=0x%x\n", (uint8_t)(address | 0x1));
-				D_EXIT();
+				//_DEBUG("ACK for address=0x%x\n", (uint8_t)(address | 0x1));
+				//D_EXIT();
 				return RT_ERR_OK;
 			}
-			RT_TIMEOUT_CHECK( RT_DEFAULT_TIMEOUT );
 		}
 	}
 	// We should not fall this far
-	D_EXIT();
+	//D_EXIT();
 	return RT_ERR_ERROR;
 }
 
 /* Send one byte to I2C bus */
 rt_error platform_i2c_send_byte( unsigned id, u8 data )
 {
-	D_ENTER();
+	//D_ENTER();
 	I2C_SendData(i2c[id], data);
 	RT_TIMEOUT_INIT();
 	// wait for I2C1 EV8_2 --> byte has been transmitted
 	while(!I2C_CheckEvent(i2c[id], I2C_EVENT_MASTER_BYTE_TRANSMITTED))
 	{
-		_DEBUG("waiting for byte to be sent, status reg value=%x\n", (unsigned int)I2C_GetLastEvent(i2c[id]));
+		//_DEBUG("waiting for byte to be sent, status reg value=%x\n", (unsigned int)I2C_GetLastEvent(i2c[id]));
 		I2C_CHECK_BERR();
 		RT_TIMEOUT_CHECK( RT_DEFAULT_TIMEOUT );
 	}
-	_DEBUG("byte to sent, status reg value=%x\n", (unsigned int)I2C_GetLastEvent(i2c[id]));
-	D_EXIT();
+	//_DEBUG("byte to sent, status reg value=%x\n", (unsigned int)I2C_GetLastEvent(i2c[id]));
+	//D_EXIT();
 	return RT_ERR_OK;
 }
 
 /* This function reads one byte from the slave device */
 rt_error platform_i2c_recv_byte( unsigned id, int ack, u8 *buff)
 {
-	D_ENTER();
+	//D_ENTER();
 	if(ack) // enable acknowledge of recieved data
 	{
 		I2C_AcknowledgeConfig(i2c[id], ENABLE);
@@ -284,13 +297,13 @@ rt_error platform_i2c_recv_byte( unsigned id, int ack, u8 *buff)
 	// wait until one byte has been received
 	while( !I2C_CheckEvent(i2c[id], I2C_EVENT_MASTER_BYTE_RECEIVED) )
 	{
-		_DEBUG("waiting for byte to be received, status reg value=%x\n", (unsigned int)I2C_GetLastEvent(i2c[id]));
+		//_DEBUG("waiting for byte to be received, status reg value=%x\n", (unsigned int)I2C_GetLastEvent(i2c[id]));
 		I2C_CHECK_BERR();
 		RT_TIMEOUT_CHECK( RT_DEFAULT_TIMEOUT );
 	}
 	// read data from I2C data register and return data byte
 	*buff = I2C_ReceiveData(i2c[id]);
-	D_EXIT();
+	//D_EXIT();
 	return RT_ERR_OK;
 }
 


### PR DESCRIPTION
Error handling to I2C, proper handling of repeated starts and a ton of other "details" that were glossed over by eLua. To be fair the same details are glossed over by every reference implementation I could find.

Anyway accessing I2C devices now works, also includes a handy baseclass for basic I2C operations on a device, it can be subclassed to provider nicer API for accessing the accelerometer (or any other device).
