### PR TITLE
low-power modes, entering and recovery, RTC shell commands for testing wakeup.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,6 +221,10 @@ else
   DDEFS += -DCORTEX_USE_FPU=FALSE
 endif
 
+ifeq ($(ENABLE_WFI_IDLE),yes)
+  DDEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
+endif
+
 ifeq ($(USE_FWLIB),yes)
   include $(CHIBIOS)/ext/stm32lib/stm32lib.mk
   CSRC += $(STM32SRC)

--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,7 @@ CSRC = $(PORTSRC) \
        $(BOARDSRC) \
        $(CHIBIOS)/os/various/shell.c \
        $(CHIBIOS)/os/various/chprintf.c \
+       $(CHIBIOS)/os/various/chrtclib.c \
        $(CHIBIOS)/os/various/syscalls.c \
        drivers/slre.c \
        drivers/gps.c \
@@ -94,6 +95,7 @@ CSRC = $(PORTSRC) \
        drivers/usb_serial.c \
        drivers/sha1.c \
        drivers/reset_button.c \
+       drivers/rtchelpers.c \
        main.c
 
 # C++ sources that can be compiled in ARM or THUMB mode depending on the global

--- a/boards/ruuviC2/board.mk
+++ b/boards/ruuviC2/board.mk
@@ -4,6 +4,7 @@ BOARDSRC = boards/ruuviC2/board.c boards/ruuviC2/power.c
 # Required include directories
 BOARDINC = boards/ruuviC2
 
+ENABLE_WFI_IDLE = yes
 USE_FPU = yes
 
 .DEFAULT_GOAL := all

--- a/boards/ruuviC2/board.mk
+++ b/boards/ruuviC2/board.mk
@@ -4,6 +4,7 @@ BOARDSRC = boards/ruuviC2/board.c boards/ruuviC2/power.c
 # Required include directories
 BOARDINC = boards/ruuviC2
 
+# Having trouble with SWD ? http://kirjoitusalusta.fi/ruuvitracker-swd-vs-wfi
 ENABLE_WFI_IDLE = yes
 USE_FPU = yes
 

--- a/boards/ruuviC2/power.h
+++ b/boards/ruuviC2/power.h
@@ -26,4 +26,44 @@ void power_request(enum POWER_DOMAIN);
  */
 void power_release(enum POWER_DOMAIN);
 
+
+/**
+ * puts the MCU to STOP mode
+ *
+ * I/Os retain state but main clock is stopped
+ */
+void power_enter_stop(void);
+
+/**
+ * puts the MCU to STANDBY mode
+ *
+ * Everything is shut down, when the MCU comes back up it starts with frsh RAM etc
+ */
+void power_enter_standby(void);
+
+/**
+ * Helper to register a callback to the PA0 button and RTC wakeup
+ *
+ * Used by power_enter_stop() to register power_wakeup_callback()
+ */
+void register_power_wakeup_callback(extcallback_t cb);
+
+/**
+ * Callback that handles restarting clocks etc when coming back from STOP mode
+ *
+ * This will override any previous callback in the PA0 or RTC interrupts
+ */
+void power_wakeup_callback(EXTDriver *extp, expchannel_t channel);
+
+/**
+ * Shell command to enter STOP mode
+ */
+void cmd_stop(BaseSequentialStream *chp, int argc, char *argv[]);
+
+/**
+ * Shell command to enter STANDBY mode
+ */
+void cmd_standby(BaseSequentialStream *chp, int argc, char *argv[]);
+
+
 #endif /* POWER_H */

--- a/chconf.h
+++ b/chconf.h
@@ -54,9 +54,12 @@
  *
  * @note    Disabling the round robin preemption makes the kernel more compact
  *          and generally faster.
+ *
+ * @see     http://www.chibios.org/dokuwiki/doku.php?id=chibios:kb:round_robin
+ * @see     http://www.chibios.org/dokuwiki/doku.php?id=chibios:kb:power
  */
 #if !defined(CH_TIME_QUANTUM) || defined(__DOXYGEN__)
-#define CH_TIME_QUANTUM                 20
+#define CH_TIME_QUANTUM                 0
 #endif
 
 /**
@@ -107,9 +110,11 @@
  *
  * @note    This is not related to the compiler optimization options.
  * @note    The default is @p TRUE.
+ *
+ * @see     http://www.chibios.org/dokuwiki/doku.php?id=chibios:kb:power
  */
 #if !defined(CH_OPTIMIZE_SPEED) || defined(__DOXYGEN__)
-#define CH_OPTIMIZE_SPEED               FALSE
+#define CH_OPTIMIZE_SPEED               TRUE
 #endif
 
 /** @} */

--- a/drivers/rtchelpers.c
+++ b/drivers/rtchelpers.c
@@ -1,0 +1,117 @@
+#include "drivers/rtchelpers.h"
+#include "chprintf.h"
+#include <string.h>
+#include <stdlib.h>
+#include <time.h>
+
+void cmd_alarm(BaseSequentialStream *chp, int argc, char *argv[])
+{
+  int i = 0;
+
+  RTCAlarm alarmspec;
+
+  (void)argv;
+  if (argc < 1) {
+    goto ERROR;
+  }
+
+  if ((argc == 1) && (strcmp(argv[0], "get") == 0)){
+    rtcGetAlarm(&RTCD1, 0, &alarmspec);
+    chprintf(chp, "%D%s",alarmspec," - alarm in STM internal format\r\n");
+    return;
+  }
+
+  if ((argc == 2) && (strcmp(argv[0], "set") == 0)){
+    i = atol(argv[1]);
+    alarmspec.tv_datetime = ((i / 10) & 7 << 4) | (i % 10) | RTC_ALRMAR_MSK4 |
+                            RTC_ALRMAR_MSK3 | RTC_ALRMAR_MSK2;
+    rtcSetAlarm(&RTCD1, 0, &alarmspec);
+    return;
+  }
+  else{
+    goto ERROR;
+  }
+
+ERROR:
+  chprintf(chp, "Usage: alarm get\r\n");
+  chprintf(chp, "       alarm set N\r\n");
+  chprintf(chp, "where N is alarm time in seconds\r\n");
+}
+
+void cmd_date(BaseSequentialStream *chp, int argc, char *argv[])
+{
+  (void)argv;
+  struct tm timp;
+  time_t unix_time;
+
+  if (argc == 0) {
+    goto ERROR;
+  }
+
+  if ((argc == 1) && (strcmp(argv[0], "get") == 0)){
+    unix_time = rtcGetTimeUnixSec(&RTCD1);
+
+    if (unix_time == -1){
+      chprintf(chp, "incorrect time in RTC cell\r\n");
+    }
+    else{
+      chprintf(chp, "%D%s",unix_time," - unix time\r\n");
+      rtcGetTimeTm(&RTCD1, &timp);
+      chprintf(chp, "%s%s",asctime(&timp)," - formatted time string\r\n");
+    }
+    return;
+  }
+
+  if ((argc == 2) && (strcmp(argv[0], "set") == 0)){
+    unix_time = atol(argv[1]);
+    if (unix_time > 0){
+      rtcSetTimeUnixSec(&RTCD1, unix_time);
+      return;
+    }
+    else{
+      goto ERROR;
+    }
+  }
+  else{
+    goto ERROR;
+  }
+
+ERROR:
+  chprintf(chp, "Usage: date get\r\n");
+  chprintf(chp, "       date set N\r\n");
+  chprintf(chp, "where N is time in seconds sins Unix epoch\r\n");
+  chprintf(chp, "you can get current N value from unix console by the command\r\n");
+  chprintf(chp, "%s", "date +\%s\r\n");
+  return;
+}
+
+void cmd_wakeup(BaseSequentialStream *chp, int argc, char *argv[])
+{
+  RTCWakeup wakeupspec;
+  int i = 0;
+
+  (void)argv;
+  if (argc < 1) {
+    goto ERROR;
+  }
+
+  if ((argc == 1) && (strcmp(argv[0], "get") == 0)){
+    rtcGetPeriodicWakeup_v2(&RTCD1, &wakeupspec);
+    chprintf(chp, "%D%s",wakeupspec," - alarm in STM internal format\r\n");
+    return;
+  }
+
+  if ((argc == 2) && (strcmp(argv[0], "set") == 0)){
+    i = atoi(argv[1]);
+    wakeupspec.wakeup = ((uint32_t)4) << 16; /* select 1 Hz clock source */
+    wakeupspec.wakeup |= i-1; /* set counter value to i-1. Period will be i+1 seconds. */
+    rtcSetPeriodicWakeup_v2(&RTCD1, &wakeupspec);
+    return;
+  }
+
+ERROR:
+  chprintf(chp, "Usage: wakeup get\r\n");
+  chprintf(chp, "       wakeup set N\r\n");
+  chprintf(chp, "where N is recurring alarm time in seconds\r\n");
+}
+

--- a/drivers/rtchelpers.h
+++ b/drivers/rtchelpers.h
@@ -1,0 +1,28 @@
+#ifndef RTCHELPERS_H
+#define RTCHELPERS_H
+#include "ch.h"
+#include "hal.h"
+#include "chrtclib.h"
+
+/**
+ * shell command to set or get alarm0
+ *
+ * The set argument takes unixtime (seconds since epoch)
+ */
+void cmd_alarm(BaseSequentialStream *chp, int argc, char *argv[]);
+
+/**
+ * shell command to set or display the RTC datetime
+ *
+ * The set argument takes unixtime (seconds since epoch)
+ */
+void cmd_date(BaseSequentialStream *chp, int argc, char *argv[]);
+
+/**
+ * Shell command to set the recurring wakeup timer (or get the value)
+ *
+ * The set argument takes interval as seconds
+ */
+void cmd_wakeup(BaseSequentialStream *chp, int argc, char *argv[]);
+
+#endif

--- a/halconf.h
+++ b/halconf.h
@@ -111,7 +111,7 @@
  * @brief   Enables the RTC subsystem.
  */
 #if !defined(HAL_USE_RTC) || defined(__DOXYGEN__)
-#define HAL_USE_RTC                 FALSE
+#define HAL_USE_RTC                 TRUE
 #endif
 
 /**

--- a/main.c
+++ b/main.c
@@ -22,6 +22,7 @@
 #include "test.h"
 
 #include "shell.h"
+#include "drivers/debug.h"
 #include "chprintf.h"
 #include "power.h"
 #include "drivers/usb_serial.h"
@@ -168,7 +169,6 @@ static void cmd_http(BaseSequentialStream *chp, int argc, char *argv[])
     }
 }
 
-
 static const ShellCommand commands[] = {
     {"mem", cmd_mem},
     {"threads", cmd_threads},
@@ -176,6 +176,8 @@ static const ShellCommand commands[] = {
     {"gps_test", cmd_gps},
     {"gsm", cmd_gsm},
     {"http", cmd_http},
+    {"stop", cmd_stop},
+    {"standby", cmd_standby},
     {NULL, NULL}
 };
 
@@ -212,6 +214,7 @@ static void Thread1(void *arg)
 /*
  * Application entry point.
  */
+static const EXTConfig extcfg; 
 int main(void)
 {
     Thread *shelltp = NULL;
@@ -232,7 +235,11 @@ int main(void)
     usb_serial_init();
 
     /* Initializes reset button PA0 */
+    /**
+     * This messes my button wakeup
     button_init();
+     */
+    extStart(&EXTD1, &extcfg);
 
     /*
      * Shell manager initialization.

--- a/main.c
+++ b/main.c
@@ -17,6 +17,9 @@
 #include <stdio.h>
 #include <string.h>
 
+#include <stdlib.h>
+#include <time.h>
+
 #include "ch.h"
 #include "hal.h"
 #include "test.h"
@@ -30,6 +33,7 @@
 #include "drivers/gsm.h"
 #include "drivers/http.h"
 #include "drivers/reset_button.h"
+#include "drivers/rtchelpers.h"
 
 
 /*===========================================================================*/
@@ -73,6 +77,12 @@ static void cmd_threads(BaseSequentialStream *chp, int argc, char *argv[])
                  states[tp->p_state], (uint32_t)tp->p_time);
         tp = chRegNextThread(tp);
     } while (tp != NULL);
+#ifdef CORTEX_ENABLE_WFI_IDLE
+    chprintf(chp, "CRTX_ENABLE_WFI_IDLE=%d\r\n", CORTEX_ENABLE_WFI_IDLE);
+#endif
+#ifdef ENABLE_WFI_IDLE
+    chprintf(chp, "ENBL_WFI_IDLE=%d\r\n", ENABLE_WFI_IDLE);
+#endif
 }
 
 static void cmd_test(BaseSequentialStream *chp, int argc, char *argv[])
@@ -178,6 +188,9 @@ static const ShellCommand commands[] = {
     {"http", cmd_http},
     {"stop", cmd_stop},
     {"standby", cmd_standby},
+    {"date", cmd_date},
+    {"alarm", cmd_alarm},
+    {"wakeup", cmd_wakeup},
     {NULL, NULL}
 };
 


### PR DESCRIPTION
Conflicts with using the onboard button for reset etc, we need to figure out some way to share the functionality (likely the solution is posting an event flag from the wakeup ISR if the button was used for wakeup)
