### PR TITLE
I2c pinmux fix

### DIFF
--- a/boards/ruuviC2/board.h
+++ b/boards/ruuviC2/board.h
@@ -279,8 +279,8 @@
                                      PIN_OTYPE_PUSHPULL(GPIOB_JTAG_TDO) | \
                                      PIN_OTYPE_PUSHPULL(GPIOB_JTAG_TRST)| \
                                      PIN_OTYPE_PUSHPULL(GPIOB_PIN5)     | \
-                                     PIN_OTYPE_PUSHPULL(GPIOB_SCL)      | \
-                                     PIN_OTYPE_PUSHPULL(GPIOB_SDA)      | \
+                                     PIN_OTYPE_OPENDRAIN(GPIOB_SCL)      | \
+                                     PIN_OTYPE_OPENDRAIN(GPIOB_SDA)      | \
                                      PIN_OTYPE_PUSHPULL(GPIOB_LED1) |       \
                                      PIN_OTYPE_PUSHPULL(GPIOB_LED2) |       \
 				     PIN_OTYPE_PUSHPULL(GPIOB_GSM_RXD) |    \

--- a/main.c
+++ b/main.c
@@ -35,13 +35,14 @@
 #include "drivers/reset_button.h"
 #include "drivers/rtchelpers.h"
 
-/* I2C interface #2 */
+/* I2C interface #1 */
+// TODO: This should probably be defined in board.h or something. It needs to be globally accessible because in case of I2C timeout we *must* reinit the whole I2C subsystem
 static const I2CConfig i2cfg1 = {
     OPMODE_I2C,
     400000,
     FAST_DUTY_CYCLE_2,
 };
-
+// TODO: I guess this does not have to be global
 static i2cflags_t i2c_errors = 0;
 
 


### PR DESCRIPTION
Fixes pinmux for I2C (before this we always would get NACK from the slave since STM was actively driving the line high). Adds a shell command to verify we can read data over I2C.
